### PR TITLE
 Return a new copy of credentials.Servers

### DIFF
--- a/MediaBrowser.ApiInteraction/ConnectionManager.cs
+++ b/MediaBrowser.ApiInteraction/ConnectionManager.cs
@@ -155,7 +155,7 @@ namespace MediaBrowser.ApiInteraction
 
             await _credentialProvider.SaveServerCredentials(credentials).ConfigureAwait(false);
 
-            return servers;
+            return credentials.Servers.ToList();
         }
 
         private async Task<IEnumerable<ServerInfo>> GetConnectServers(string userId, CancellationToken cancellationToken)


### PR DESCRIPTION
 Return a new copy of credentials.Servers instead of previous copy that didn't include the detected or updated servers.
